### PR TITLE
Zero-alloc and performance improvements

### DIFF
--- a/ThumbHash.sln
+++ b/ThumbHash.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{9922EF40
 		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThumbHash.Benchmarks", "bench\ThumbHash.Benchmarks.csproj", "{CE953B4C-43B8-402A-AA29-689973D22BDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{24771381-7EA1-445D-B58F-953EDF01333A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24771381-7EA1-445D-B58F-953EDF01333A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{24771381-7EA1-445D-B58F-953EDF01333A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE953B4C-43B8-402A-AA29-689973D22BDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE953B4C-43B8-402A-AA29-689973D22BDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE953B4C-43B8-402A-AA29-689973D22BDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE953B4C-43B8-402A-AA29-689973D22BDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -57,9 +57,9 @@ public class Benchmarks
 
     [Benchmark]
     [ArgumentsSource(nameof(Images_NoAlpha))]
-    public byte[] RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(image.Width, image.Height, image.GetPixelSpan());
+    public int RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
 
     [Benchmark]
     [ArgumentsSource(nameof(Images_Alpha))]
-    public byte[] RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(image.Width, image.Height, image.GetPixelSpan());
+    public int RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
 }

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -1,10 +1,13 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
 using SkiaSharp;
 using System.Collections.Generic;
 using System.IO;
 
 namespace ThumbHash.Benchmarks;
 
+[MemoryDiagnoser]
+[HardwareCounters(HardwareCounter.BranchInstructions, HardwareCounter.BranchMispredictions)]
 public class Benchmarks
 {
     private static SKBitmap GetBitmap(string path, bool fixPremul = false)

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using SkiaSharp;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -55,6 +56,26 @@ public class Benchmarks
         }
     }
 
+    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
+    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
+
+    public static IEnumerable<object> ThumbHashes_NoAlpha
+    {
+        get
+        {
+            yield return FlowerThumbHash;
+        }
+    }
+
+    public static IEnumerable<object> ThumbHashes_Alpha
+    {
+        get
+        {
+            yield return TuxThumbHash;
+        }
+    }
+
+
     [Benchmark]
     [ArgumentsSource(nameof(Images_NoAlpha))]
     public int RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
@@ -62,4 +83,12 @@ public class Benchmarks
     [Benchmark]
     [ArgumentsSource(nameof(Images_Alpha))]
     public int RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
+    public (int,int,byte[]) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ThumbHashes_Alpha))]
+    public (int, int, byte[]) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
 }

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -1,0 +1,62 @@
+﻿using BenchmarkDotNet.Attributes;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ThumbHash.Benchmarks;
+
+public class Benchmarks
+{
+    private static SKBitmap GetBitmap(string path, bool fixPremul = false)
+    {
+        using var skbmp = fixPremul
+            ? SKBitmap.Decode(path, SKBitmap.DecodeBounds(path).WithAlphaType(SKAlphaType.Unpremul))
+            : SKBitmap.Decode(path);
+        var result = skbmp.Copy(SKColorType.Rgba8888);
+        return result;
+    }
+
+    private static string AssetBase
+    {
+        get
+        {
+            var cwd = Directory.GetCurrentDirectory();
+
+            string assetsDir;
+            while (!Directory.Exists(assetsDir = Path.Join(cwd, "assets")))
+            {
+                cwd = Path.GetDirectoryName(cwd);
+            }
+
+            return assetsDir;
+        }
+    }
+
+    private static readonly SKBitmap Flower = GetBitmap(Path.Join(AssetBase, "flower.jpg"));
+
+    private static readonly SKBitmap Tux = GetBitmap(Path.Join(AssetBase, "tux.png"));
+
+    public static IEnumerable<object> Images_NoAlpha
+    {
+        get
+        {
+            yield return Flower;
+        }
+    }
+
+    public static IEnumerable<object> Images_Alpha
+    {
+        get
+        {
+            yield return Tux;
+        }
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Images_NoAlpha))]
+    public byte[] RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(image.Width, image.Height, image.GetPixelSpan());
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Images_Alpha))]
+    public byte[] RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(image.Width, image.Height, image.GetPixelSpan());
+}

--- a/bench/Program.cs
+++ b/bench/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/bench/RgbaToThumbHashBenchmarks.cs
+++ b/bench/RgbaToThumbHashBenchmarks.cs
@@ -9,7 +9,7 @@ namespace ThumbHash.Benchmarks;
 
 [MemoryDiagnoser]
 [HardwareCounters(HardwareCounter.BranchInstructions, HardwareCounter.BranchMispredictions)]
-public class Benchmarks
+public class RgbaToThumbHashBenchmarks
 {
     private static SKBitmap GetBitmap(string path, bool fixPremul = false)
     {

--- a/bench/RgbaToThumbHashBenchmarks.cs
+++ b/bench/RgbaToThumbHashBenchmarks.cs
@@ -1,7 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using SkiaSharp;
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -38,7 +37,7 @@ public class RgbaToThumbHashBenchmarks
 
     private static readonly SKBitmap Flower = GetBitmap(Path.Join(AssetBase, "flower.jpg"));
 
-    private static readonly SKBitmap Tux = GetBitmap(Path.Join(AssetBase, "tux.png"));
+    private static readonly SKBitmap Tux = GetBitmap(Path.Join(AssetBase, "tux.png"), fixPremul: true);
 
     public static IEnumerable<object> Images_NoAlpha
     {
@@ -56,26 +55,6 @@ public class RgbaToThumbHashBenchmarks
         }
     }
 
-    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
-    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
-
-    public static IEnumerable<object> ThumbHashes_NoAlpha
-    {
-        get
-        {
-            yield return FlowerThumbHash;
-        }
-    }
-
-    public static IEnumerable<object> ThumbHashes_Alpha
-    {
-        get
-        {
-            yield return TuxThumbHash;
-        }
-    }
-
-
     [Benchmark]
     [ArgumentsSource(nameof(Images_NoAlpha))]
     public int RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
@@ -83,12 +62,4 @@ public class RgbaToThumbHashBenchmarks
     [Benchmark]
     [ArgumentsSource(nameof(Images_Alpha))]
     public int RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
-
-    [Benchmark]
-    [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
-    public (int,int,byte[]) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(ThumbHashes_Alpha))]
-    public (int, int, byte[]) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
 }

--- a/bench/ThumbHash.Benchmarks.csproj
+++ b/bench/ThumbHash.Benchmarks.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+	
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\src\ThumbHash\ThumbHash.csproj" />
+  </ItemGroup>
+</Project>

--- a/bench/ThumbHashToRgbaBenchmarks.cs
+++ b/bench/ThumbHashToRgbaBenchmarks.cs
@@ -1,0 +1,38 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using System;
+using System.Collections.Generic;
+
+namespace ThumbHash.Benchmarks;
+
+[MemoryDiagnoser]
+[HardwareCounters(HardwareCounter.BranchInstructions, HardwareCounter.BranchMispredictions)]
+public class ThumbHashToRgbaBenchmarks
+{
+    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
+    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
+
+    public static IEnumerable<object> ThumbHashes_NoAlpha
+    {
+        get
+        {
+            yield return FlowerThumbHash;
+        }
+    }
+
+    public static IEnumerable<object> ThumbHashes_Alpha
+    {
+        get
+        {
+            yield return TuxThumbHash;
+        }
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
+    public (int,int,byte[]) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ThumbHashes_Alpha))]
+    public (int, int, byte[]) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
+}

--- a/bench/ThumbHashToRgbaBenchmarks.cs
+++ b/bench/ThumbHashToRgbaBenchmarks.cs
@@ -30,9 +30,9 @@ public class ThumbHashToRgbaBenchmarks
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
-    public (int,int) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[100 * 100 * 4]);
+    public (int,int) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_Alpha))]
-    public (int, int) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[100 * 100 * 4]);
+    public (int, int) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
 }

--- a/bench/ThumbHashToRgbaBenchmarks.cs
+++ b/bench/ThumbHashToRgbaBenchmarks.cs
@@ -30,9 +30,9 @@ public class ThumbHashToRgbaBenchmarks
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
-    public (int,int,byte[]) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
+    public (int,int) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[100 * 100 * 4]);
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_Alpha))]
-    public (int, int, byte[]) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash);
+    public (int, int) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[100 * 100 * 4]);
 }

--- a/src/ThumbHash/SpanOwner.cs
+++ b/src/ThumbHash/SpanOwner.cs
@@ -1,0 +1,43 @@
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ThumbHash;
+
+internal readonly ref struct SpanOwner<T>
+{
+    private readonly T[] _buffer;
+    private readonly int _length;
+
+    public static SpanOwner<T> Empty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => new(0);
+    }
+
+    public Span<T> Span
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ref T r0 = ref MemoryMarshal.GetArrayDataReference(_buffer);
+            return MemoryMarshal.CreateSpan(ref r0, _length);
+        }
+    }
+
+    public SpanOwner<T> WithLength(int length) => new(length, _buffer);
+
+    public SpanOwner(int length) : this(length, ArrayPool<T>.Shared.Rent(length))
+    {
+    }
+    private SpanOwner(int length, T[] buffer)
+    {
+        _length = length;
+        _buffer = buffer;
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<T>.Shared.Return(_buffer);
+    }
+}

--- a/src/ThumbHash/SpanOwner.cs
+++ b/src/ThumbHash/SpanOwner.cs
@@ -31,17 +31,21 @@ internal readonly ref struct SpanOwner<T>
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SpanOwner<T> WithLength(int length) => new(length, _buffer);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SpanOwner(int length) : this(length, DefaultPool.Rent(length))
     {
     }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private SpanOwner(int length, T[] buffer)
     {
         _length = length;
         _buffer = buffer;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
         DefaultPool.Return(_buffer);

--- a/src/ThumbHash/SpanOwner.cs
+++ b/src/ThumbHash/SpanOwner.cs
@@ -6,6 +6,12 @@ namespace ThumbHash;
 
 internal readonly ref struct SpanOwner<T>
 {
+    private static ArrayPool<T> DefaultPool
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ArrayPool<T>.Shared;
+    }
+
     private readonly T[] _buffer;
     private readonly int _length;
 
@@ -27,7 +33,7 @@ internal readonly ref struct SpanOwner<T>
 
     public SpanOwner<T> WithLength(int length) => new(length, _buffer);
 
-    public SpanOwner(int length) : this(length, ArrayPool<T>.Shared.Rent(length))
+    public SpanOwner(int length) : this(length, DefaultPool.Rent(length))
     {
     }
     private SpanOwner(int length, T[] buffer)
@@ -38,6 +44,6 @@ internal readonly ref struct SpanOwner<T>
 
     public void Dispose()
     {
-        ArrayPool<T>.Shared.Return(_buffer);
+        DefaultPool.Return(_buffer);
     }
 }

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -12,6 +12,7 @@ public static class ThumbHash
         public readonly SpanOwner<float> AC;
         public readonly float Scale;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Channel(float dc, SpanOwner<float> ac, float scale)
         {
             DC = dc;
@@ -19,6 +20,7 @@ public static class ThumbHash
             Scale = scale;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Deconstruct(out float dc, out SpanOwner<float> ac, out float scale)
         {
             dc = DC;
@@ -35,6 +37,7 @@ public static class ThumbHash
         public readonly byte B;
         public readonly byte A;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public RGBA(byte r, byte g, byte b, byte a)
         {
             R = r;
@@ -43,6 +46,7 @@ public static class ThumbHash
             A = a;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
         {
             r = R;

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -104,7 +104,7 @@ public static class ThumbHash
     /// <param name="hash"></param>
     /// <param name="w">The width of the input image. Must be ≤100px.</param>
     /// <param name="h">The height of the input image. Must be ≤100px.</param>
-    /// <param name="rgba">The pixels in the input image, row-by-row. RGB should not be premultiplied by A. Must have `w*h*4` elements.</param>
+    /// <param name="rgba_bytes">The pixels in the input image, row-by-row. RGB should not be premultiplied by A. Must have `w*h*4` elements.</param>
     /// <returns>Number of bytes written into hash span</returns>
     public static int RgbaToThumbHash(Span<byte> hash, int w, int h, ReadOnlySpan<byte> rgba_bytes)
     {

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -135,16 +135,15 @@ public static class ThumbHash
         var lx = Math.Max((int)MathF.Round(l_limit * w / MathF.Max(w, h)), 1);
         var ly = Math.Max((int)MathF.Round(l_limit * h / MathF.Max(w, h)), 1);
 
-        using var lpqa_owner = new SpanOwner<float>(w * h * 4);
-        Span<float> lpqa = lpqa_owner.Span,
-            // l: luminance
-            l = lpqa[0..(w * h)],
-            // p: yellow - blue
-            p = lpqa[(w * h)..(w * h * 2)],
-            // q: red - green
-            q = lpqa[(w * h * 2)..(w * h * 3)],
-            // a: alpha
-            a = lpqa[(w * h * 3)..];
+        using var l_owner = new SpanOwner<float>(w * h); // l: luminance
+        using var p_owner = new SpanOwner<float>(w * h); // p: yellow - blue
+        using var q_owner = new SpanOwner<float>(w * h); // q: red - green
+        using var a_owner = new SpanOwner<float>(w * h); // a: alpha
+
+        var l = l_owner.Span;
+        var p = p_owner.Span;
+        var q = q_owner.Span;
+        var a = a_owner.Span;
 
         // Convert the image from RGBA to LPQA (composite atop the average color)
         for (int i = 0, j = 0; i < rgba.Length; i += 4, j++)

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -148,14 +148,15 @@ public static class ThumbHash
         // Convert the image from RGBA to LPQA (composite atop the average color)
         for (int i = 0, j = 0; i < rgba.Length; i += 4, j++)
         {
-            var alpha = rgba[i + 3] / 255.0f;
-            var r = avg_r * (1.0f - alpha) + alpha / 255.0f * rgba[i + 0];
-            var g = avg_g * (1.0f - alpha) + alpha / 255.0f * rgba[i + 1];
-            var b = avg_b * (1.0f - alpha) + alpha / 255.0f * rgba[i + 2];
-            l[j] = (r + g + b) / 3.0f;
-            p[j] = (r + g) / 2.0f - b;
-            q[j] = r - g;
+            var pixel = rgba.Slice(i, 4);
+            var alpha = pixel[3] / 255.0f;
+            var b = avg_b * (1.0f - alpha) + alpha / 255.0f * pixel[2];
+            var g = avg_g * (1.0f - alpha) + alpha / 255.0f * pixel[1];
+            var r = avg_r * (1.0f - alpha) + alpha / 255.0f * pixel[0];
             a[j] = alpha;
+            q[j] = r - g;
+            p[j] = (r + g) / 2.0f - b;
+            l[j] = (r + g + b) / 3.0f;
         }
 
         // Encode using the DCT into DC (constant) and normalized AC (varying) terms

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -59,8 +59,11 @@ public static class ThumbHash
     private const int MaxHash = 25;
     private const int MinHash = 5;
 
-    private const int MaxWidth = 100;
-    private const int MaxHeight = 100;
+    private const int MaxRgbaWidth = 100;
+    private const int MaxRgbaHeight = 100;
+
+    private const int MaxThumbHashWidth = 32;
+    private const int MaxThumbHashHeight = 32;
 
     #region ThrowHelpers
 #if !NET8_0_OR_GREATER
@@ -119,17 +122,17 @@ public static class ThumbHash
 
         // Encoding an image larger than 100x100 is slow with no benefit
 #if NET8_0_OR_GREATER
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(w, MaxWidth);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(h, MaxHeight);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(w, MaxRgbaWidth);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(h, MaxRgbaHeight);
 #else
-        if (w > MaxWidth)
+        if (w > MaxRgbaWidth)
         {
-            ThrowIfGreaterThan(w, MaxWidth);
+            ThrowIfGreaterThan(w, MaxRgbaWidth);
         }
 
-        if (h > MaxHeight)
+        if (h > MaxRgbaHeight)
         {
-            ThrowIfGreaterThan(h, MaxHeight);
+            ThrowIfGreaterThan(h, MaxRgbaHeight);
         }
 #endif
 
@@ -321,7 +324,7 @@ public static class ThumbHash
     /// <exception cref="System.ArgumentOutOfRangeException">Thrown if the input is too short.</exception>
     public static (int w, int h, byte[] rgba) ThumbHashToRgba(ReadOnlySpan<byte> hash)
     {
-        using var rgba_owner = new SpanOwner<byte>(MaxWidth * MaxHeight * 4);
+        using var rgba_owner = new SpanOwner<byte>(MaxThumbHashWidth * MaxThumbHashHeight * 4);
         var rgba = rgba_owner.Span;
         var (w, h) = ThumbHashToRgba(hash, rgba);
         return (w, h, rgba[..(w * h * 4)].ToArray());
@@ -332,6 +335,7 @@ public static class ThumbHash
     /// </summary>
     /// <returns>Width, height, and unpremultiplied RGBA8 pixels of the rendered ThumbHash.</returns>
     /// <exception cref="System.ArgumentOutOfRangeException">Thrown if the input is too short.</exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">Thrown if the RGBA span length is less than `w * h * 4` bytes.</exception>
     public static (int w, int h) ThumbHashToRgba(ReadOnlySpan<byte> hash, Span<byte> rgba)
     {
         var ratio = ThumbHashToApproximateAspectRatio(hash);
@@ -373,7 +377,7 @@ public static class ThumbHash
         };
 
         // Decode using the DCT into RGB
-        var (w, h) = ratio > 1.0f ? (32, (int)MathF.Round(32.0f / ratio)) : ((int)MathF.Round(32.0f * ratio), 32);
+        var (w, h) = ratio > 1.0f ? (MaxThumbHashWidth, (int)MathF.Round(32.0f / ratio)) : ((int)MathF.Round(32.0f * ratio), MaxThumbHashHeight);
 #if NET8_0_OR_GREATER
         ArgumentOutOfRangeException.ThrowIfLessThan(rgba.Length, w * h * 4);
 #else

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -370,9 +370,10 @@ public static class ThumbHash
         fx.Clear();
         fy.Clear();
 
-        for (int y = 0, i = 0; y < h; y++)
+        ref RGBA pixel = ref MemoryMarshal.AsRef<RGBA>(rgba_array);
+        for (int y = 0; y < h; y++)
         {
-            for (int x = 0; x < w; x++, i += 4)
+            for (int x = 0; x < w; x++, pixel = ref Unsafe.Add(ref pixel, 1))
             {
                 var l = l_dc;
                 var p = p_dc;
@@ -438,11 +439,11 @@ public static class ThumbHash
                 var r = (3.0f * l - b + q) / 2.0f;
                 var g = r - q;
 
-                Span<byte> rgba = rgba_array.AsSpan(i, 4);
-                rgba[0] = (byte)(Math.Clamp(r, 0.0f, 1.0f) * 255.0f);
-                rgba[1] = (byte)(Math.Clamp(g, 0.0f, 1.0f) * 255.0f);
-                rgba[2] = (byte)(Math.Clamp(b, 0.0f, 1.0f) * 255.0f);
-                rgba[3] = (byte)(Math.Clamp(a, 0.0f, 1.0f) * 255.0f);
+                pixel = new(
+                    r: (byte)(Math.Clamp(r, 0.0f, 1.0f) * 255.0f),
+                    g: (byte)(Math.Clamp(g, 0.0f, 1.0f) * 255.0f),
+                    b: (byte)(Math.Clamp(b, 0.0f, 1.0f) * 255.0f),
+                    a: (byte)(Math.Clamp(a, 0.0f, 1.0f) * 255.0f));
             }
         }
 

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -9,11 +9,12 @@
 
 	<Product>ThumbHash</Product>
 	<Authors>jzebedee</Authors>
-	<VersionPrefix>1.0.1</VersionPrefix>
+	<VersionPrefix>1.0.2</VersionPrefix>
 	<Description>A very compact representation of a placeholder for an image. Store it inline with your data and show it while the real image is loading for a smoother loading experience.</Description>
 	<PackageProjectUrl>https://github.com/jzebedee/ThumbHash</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<PackageIcon>flower_thumbhash_rust.png</PackageIcon>
 
     <!-- Source Link Support -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -32,5 +33,6 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="/" />
+    <None Include="..\..\assets\flower_thumbhash_rust.png" Link="flower_thumbhash_rust.png" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -9,7 +9,7 @@
 
 	<Product>ThumbHash</Product>
 	<Authors>jzebedee</Authors>
-	<VersionPrefix>1.0.2</VersionPrefix>
+	<VersionPrefix>1.1.0</VersionPrefix>
 	<Description>A very compact representation of a placeholder for an image. Store it inline with your data and show it while the real image is loading for a smoother loading experience.</Description>
 	<PackageProjectUrl>https://github.com/jzebedee/ThumbHash</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -88,8 +88,8 @@ public class ThumbHashTests
     [Fact]
     public void RgbaToThumbHash_ThrowsOnBadPixelSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("rgba.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[3]));
-        Assert.Throws<ArgumentOutOfRangeException>("rgba.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[5]));
+        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[3]));
+        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[5]));
     }
 
     [Theory]

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -6,7 +6,7 @@ public class ThumbHashTests
 {
     private static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
 
-    private static byte[] FlowerThumbHash => new byte[] { 147, 74, 6, 45, 6, 146, 86, 195, 116, 5, 88, 103, 218, 138, 182, 103, 148, 144, 81, 7, 25 };
+    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
 
     private static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
 
@@ -16,7 +16,7 @@ public class ThumbHashTests
 
     private static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
 
-    private static byte[] TuxThumbHash => Convert.FromHexString("A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06".Replace(" ", ""));
+    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
 
     private static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
 

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -123,7 +123,13 @@ public class ThumbHashTests
     [Fact]
     public void ThumbHashToRgba_ThrowsOnBadHashSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ThumbHash.ThumbHashToRgba(stackalloc byte[4]));
+        Assert.Throws<ArgumentOutOfRangeException>("hash.Length", () => ThumbHash.ThumbHashToRgba(stackalloc byte[4]));
+    }
+
+    [Fact]
+    public void ThumbHashToRgba_ThrowsOnBadRgbaSize()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("rgba.Length", () => ThumbHash.ThumbHashToRgba(FlowerThumbHash, stackalloc byte[4]));
     }
 
     [Theory]


### PR DESCRIPTION
* Adds benchmark project
* Makes RGBA->ThumbHash and ThumbHash->RGBA zero-alloc
* Adds friendly `byte[]` overloads to keep simple heap alloc behavior for callers