### PR TITLE
V2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 name: CI build-test-pack
 on: [push, pull_request]
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-and-test:
+    name: build-and-test-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,11 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore --configuration Release
-    - name: Test
-      run: dotnet test --no-restore --no-build --configuration Release --logger trx --results-directory "TestResults"
+    - name: Test (net6.0)
+      run: dotnet test --no-restore --no-build --configuration Release --framework net6.0 --logger trx --results-directory "TestResults"
+    - name: Test (net481)
+      run: dotnet test --no-restore --no-build --configuration Release --framework net481 --logger trx --results-directory "TestResults"
+      if: matrix.os == 'windows-latest'
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ using var sk_img = SKImage.FromPixelCopy(image_info, rgba);
 using var sk_png_data = sk_img.Encode(SKEncodedImageFormat.Png, 100);
 
 using var fs_png = System.IO.File.Create("test.png");
-sk_png_data.SaveTo(fs);
+sk_png_data.SaveTo(fs_png);
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -11,10 +11,49 @@ A very compact representation of a placeholder for an image. Store it inline wit
 
 |Image|ThumbHash|ThumbHash Image|
 |-----|---------|---------------|
-|![Flower](assets/flower.jpg)|93 4A 06 2D 06 92 56 C3 74 05 58 67 DA 8A B6 67 94 90 51 07 19|<img alt="Flower ThumbHash" src="/assets/flower_thumbhash_rust.png" width=75 height=100>|
-|![Tux](assets/tux.png)|A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06|<img alt="Tux ThumbHash" src="/assets/tux_thumbhash_rust.png" width=84 height=100>|
+|![Flower](assets/flower.jpg)|<p>`93 4A 06 2D 06 92 56 C3 74 05 58 67 DA 8A B6 67 94 90 51 07 19`</p>21 bytes|<img alt="Flower ThumbHash" src="/assets/flower_thumbhash_rust.png" width=75 height=100>|
+|![Tux](assets/tux.png)|<p>`A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06`</p>25 bytes|<img alt="Tux ThumbHash" src="/assets/tux_thumbhash_rust.png" width=84 height=100>|
 
 [See a demo of ThumbHash in action _here_](https://evanw.github.io/thumbhash/).
+
+## Usage
+
+The ThumbHash library has no external dependencies and can be used on its own, or with your choice of image library (e.g., [SkiaSharp](https://github.com/mono/SkiaSharp), [ImageSharp](https://github.com/SixLabors/ImageSharp)) for rendering.
+
+Images must be in the format of unpremultiplied RGBA8888 before working with ThumbHash.
+
+### Convert an image into a thumbhash (SkiaSharp)
+```csharp
+using SkiaSharp;
+using ThumbHashes;
+
+using var original = SKBitmap.Decode("original.png");
+using var rgba8888 = original.Copy(SKColorType.Rgba8888);
+var thumbhash = ThumbHash.FromImage(rgba8888.Width, rgba8888.Height, rgba8888.GetPixelSpan());
+```
+
+### Load a thumbhash and render it to RGBA
+```csharp
+using ThumbHashes;
+
+byte[] hash = Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
+var thumbhash = new ThumbHash(hash);
+
+var (width, height, rgba) = thumbhash.ToImage();
+```
+
+### Save a rendered RGBA to a PNG (SkiaSharp)
+```csharp
+using SkiaSharp;
+
+var (width, height, rgba) = thumbhash.ToImage();
+var image_info = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+using var sk_img = SKImage.FromPixelCopy(image_info, rgba);
+using var sk_png_data = sk_img.Encode(SKEncodedImageFormat.Png, 100);
+
+using var fs_png = System.IO.File.Create("test.png");
+sk_png_data.SaveTo(fs);
+```
 
 ## Support
 

--- a/bench/RgbaToThumbHashBenchmarks.cs
+++ b/bench/RgbaToThumbHashBenchmarks.cs
@@ -4,7 +4,7 @@ using SkiaSharp;
 using System.Collections.Generic;
 using System.IO;
 
-namespace ThumbHash.Benchmarks;
+namespace ThumbHashes.Benchmarks;
 
 [MemoryDiagnoser]
 [HardwareCounters(HardwareCounter.BranchInstructions, HardwareCounter.BranchMispredictions)]
@@ -57,9 +57,9 @@ public class RgbaToThumbHashBenchmarks
 
     [Benchmark]
     [ArgumentsSource(nameof(Images_NoAlpha))]
-    public int RgbaToThumbHash_NoAlpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
+    public int RgbaToThumbHash_NoAlpha(SKBitmap image) => Utilities.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
 
     [Benchmark]
     [ArgumentsSource(nameof(Images_Alpha))]
-    public int RgbaToThumbHash_Alpha(SKBitmap image) => ThumbHash.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
+    public int RgbaToThumbHash_Alpha(SKBitmap image) => Utilities.RgbaToThumbHash(stackalloc byte[25], image.Width, image.Height, image.GetPixelSpan());
 }

--- a/bench/ThumbHashToRgbaBenchmarks.cs
+++ b/bench/ThumbHashToRgbaBenchmarks.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Diagnosers;
 using System;
 using System.Collections.Generic;
 
-namespace ThumbHash.Benchmarks;
+namespace ThumbHashes.Benchmarks;
 
 [MemoryDiagnoser]
 [HardwareCounters(HardwareCounter.BranchInstructions, HardwareCounter.BranchMispredictions)]
@@ -30,9 +30,9 @@ public class ThumbHashToRgbaBenchmarks
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_NoAlpha))]
-    public (int,int) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
+    public (int,int) ThumbHashToRgba_NoAlpha(byte[] thumbhash) => Utilities.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
 
     [Benchmark]
     [ArgumentsSource(nameof(ThumbHashes_Alpha))]
-    public (int, int) ThumbHashToRgba_Alpha(byte[] thumbhash) => ThumbHash.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
+    public (int, int) ThumbHashToRgba_Alpha(byte[] thumbhash) => Utilities.ThumbHashToRgba(thumbhash, stackalloc byte[32 * 32 * 4]);
 }

--- a/src/ThumbHash/SpanOwner.cs
+++ b/src/ThumbHash/SpanOwner.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace ThumbHash;
+namespace ThumbHashes;
 
 internal readonly ref struct SpanOwner<T>
 {
@@ -38,6 +38,7 @@ internal readonly ref struct SpanOwner<T>
     public SpanOwner(int length) : this(length, DefaultPool.Rent(length))
     {
     }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private SpanOwner(int length, T[] buffer)
     {

--- a/src/ThumbHash/SpanOwner.cs
+++ b/src/ThumbHash/SpanOwner.cs
@@ -26,8 +26,12 @@ internal readonly ref struct SpanOwner<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
+#if NET6_0_OR_GREATER
             ref T r0 = ref MemoryMarshal.GetArrayDataReference(_buffer);
             return MemoryMarshal.CreateSpan(ref r0, _length);
+#else
+            return new(_buffer, 0, _length);
+#endif
         }
     }
 

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -1,0 +1,38 @@
+﻿namespace ThumbHashes;
+
+using static Utilities;
+
+public readonly record struct ThumbHash(ReadOnlyMemory<byte> Hash)
+{
+    /// <summary>
+    /// Extracts the approximate aspect ratio of the original image.
+    /// </summary>
+    public float ApproximateAspectRatio => ThumbHashToApproximateAspectRatio(Hash.Span);
+
+    /// <summary>
+    /// Extracts the average color from a ThumbHash.
+    /// </summary>
+    /// <returns>Unpremultiplied RGBA values where each value ranges from 0 to 1. </returns>
+    public (float r, float g, float b, float a) AverageColor => ThumbHashToAverageRgba(Hash.Span);
+
+    /// <summary>
+    /// Decodes a ThumbHash to an RGBA image.
+    /// </summary>
+    /// <returns>Width, height, and unpremultiplied RGBA8 pixels of the rendered ThumbHash.</returns>
+    public (int width, int height, byte[] rgba) ToImage() => ThumbHashToRgba(Hash.Span);
+
+    /// <summary>
+    /// Decodes a ThumbHash to an RGBA image.
+    /// </summary>
+    /// <returns>Width, height, and unpremultiplied RGBA8 pixels of the rendered ThumbHash.</returns>
+    public (int width, int height) ToImage(Span<byte> rgba) => ThumbHashToRgba(Hash.Span, rgba);
+
+    /// <summary>
+    /// Encodes an RGBA image to a ThumbHash.
+    /// </summary>
+    /// <param name="width">The width of the input image. Must be ≤100px.</param>
+    /// <param name="height">The height of the input image. Must be ≤100px.</param>
+    /// <param name="rgba">The pixels in the input image, row-by-row. RGB should not be premultiplied by A. Must have `w*h*4` elements.</param>
+    public static ThumbHash FromImage(int width, int height, ReadOnlySpan<byte> rgba)
+        => new(RgbaToThumbHash(width, height, rgba));
+}

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -22,12 +22,6 @@ public readonly record struct ThumbHash(ReadOnlyMemory<byte> Hash)
     public (int width, int height, byte[] rgba) ToImage() => ThumbHashToRgba(Hash.Span);
 
     /// <summary>
-    /// Decodes a ThumbHash to an RGBA image.
-    /// </summary>
-    /// <returns>Width, height, and unpremultiplied RGBA8 pixels of the rendered ThumbHash.</returns>
-    public (int width, int height) ToImage(Span<byte> rgba) => ThumbHashToRgba(Hash.Span, rgba);
-
-    /// <summary>
     /// Encodes an RGBA image to a ThumbHash.
     /// </summary>
     /// <param name="width">The width of the input image. Must be ≤100px.</param>

--- a/src/ThumbHash/ThumbHash.cs
+++ b/src/ThumbHash/ThumbHash.cs
@@ -45,16 +45,7 @@ public static class ThumbHash
             B = b;
             A = a;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
-        {
-            r = R;
-            g = G;
-            b = B;
-            a = A;
         }
-    }
 
     private const int MaxHash = 25;
     private const int MinHash = 5;

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -10,7 +10,7 @@
 
 	<Product>ThumbHash</Product>
 	<Authors>jzebedee</Authors>
-	<VersionPrefix>1.1.0</VersionPrefix>
+	<VersionPrefix>2.0</VersionPrefix>
 	<Description>A very compact representation of a placeholder for an image. Store it inline with your data and show it while the real image is loading for a smoother loading experience.</Description>
 	<PackageProjectUrl>https://github.com/jzebedee/ThumbHash</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -29,6 +29,10 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="ErrorProne.NET.Structs" Version="0.4.0-beta.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -6,6 +6,7 @@
 	<LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsTrimmable>true</IsTrimmable>
+    <RootNamespace>ThumbHashes</RootNamespace>
 
 	<Product>ThumbHash</Product>
 	<Authors>jzebedee</Authors>

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
 	<LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -29,15 +29,32 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+
+  <!-- Always included -->
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="ErrorProne.NET.Structs" Version="0.4.0-beta.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="/" />
     <None Include="..\..\assets\flower_thumbhash_rust.png" Link="flower_thumbhash_rust.png" Pack="true" PackagePath="/" />
   </ItemGroup>
+	
+  <!-- For netstandard2.0 support -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <ItemGroup>
+		<PackageReference Include="System.Memory" Version="4.5.2" />
+	  </ItemGroup>
+	</When>
+  </Choose>
 </Project>

--- a/src/ThumbHash/Utilities.cs
+++ b/src/ThumbHash/Utilities.cs
@@ -2,9 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace ThumbHash;
+namespace ThumbHashes;
 
-public static class ThumbHash
+public static class Utilities
 {
     private readonly ref struct Channel
     {
@@ -45,7 +45,7 @@ public static class ThumbHash
             B = b;
             A = a;
         }
-        }
+    }
 
     private const int MaxHash = 25;
     private const int MinHash = 5;

--- a/test/ThumbHash.Tests/Resources.cs
+++ b/test/ThumbHash.Tests/Resources.cs
@@ -29,7 +29,7 @@ internal static class Resources
 
     internal const float FlowerAspectRatio = 0.714285731f;
 
-    internal static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
+    internal static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png");
 
     internal static byte[] TuxThumbHash => FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
 
@@ -39,12 +39,9 @@ internal static class Resources
 
     internal const float TuxAspectRatio = 0.800000011f;
 
-    private static SKBitmap GetBitmap(string path, bool fixPremul = false)
+    private static SKBitmap GetBitmap(string path)
     {
-        using var skbmp = fixPremul
-            ? SKBitmap.Decode(path, SKBitmap.DecodeBounds(path).WithAlphaType(SKAlphaType.Unpremul))
-            : SKBitmap.Decode(path);
-        var result = skbmp.Copy(SKColorType.Rgba8888);
-        return result;
+        using var skbmp = SKBitmap.Decode(path);
+        return skbmp.Copy(SKColorType.Rgba8888);
     }
 }

--- a/test/ThumbHash.Tests/Resources.cs
+++ b/test/ThumbHash.Tests/Resources.cs
@@ -4,9 +4,24 @@ namespace ThumbHashes.Tests;
 
 internal static class Resources
 {
+    private static byte[] FromHexString(string s)
+#if NET6_0_OR_GREATER
+        => Convert.FromHexString(s);
+#else
+    {
+        //this is only used for tests, so we can do it the slow and awful way
+        var ret = new byte[s.Length >> 1];
+        for (int i = 0; i < s.Length; i += 2)
+        {
+            ret[i >> 1] = Convert.ToByte(s.Substring(i, 2), 16);
+        }
+        return ret;
+    }
+#endif
+
     internal static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
 
-    internal static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
+    internal static byte[] FlowerThumbHash => FromHexString("934A062D069256C374055867DA8AB6679490510719");
 
     internal static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
 
@@ -16,7 +31,7 @@ internal static class Resources
 
     internal static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
 
-    internal static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
+    internal static byte[] TuxThumbHash => FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
 
     internal static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
 

--- a/test/ThumbHash.Tests/Resources.cs
+++ b/test/ThumbHash.Tests/Resources.cs
@@ -1,0 +1,35 @@
+﻿using SkiaSharp;
+
+namespace ThumbHashes.Tests;
+
+internal static class Resources
+{
+    internal static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
+
+    internal static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
+
+    internal static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
+
+    internal static SKBitmap FlowerThumbHashRendered => GetBitmap("Resources/flower_thumbhash_rust.png");
+
+    internal const float FlowerAspectRatio = 0.714285731f;
+
+    internal static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
+
+    internal static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
+
+    internal static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
+
+    internal static SKBitmap TuxThumbHashRendered => GetBitmap("Resources/tux_thumbhash_rust.png");
+
+    internal const float TuxAspectRatio = 0.800000011f;
+
+    private static SKBitmap GetBitmap(string path, bool fixPremul = false)
+    {
+        using var skbmp = fixPremul
+            ? SKBitmap.Decode(path, SKBitmap.DecodeBounds(path).WithAlphaType(SKAlphaType.Unpremul))
+            : SKBitmap.Decode(path);
+        var result = skbmp.Copy(SKColorType.Rgba8888);
+        return result;
+    }
+}

--- a/test/ThumbHash.Tests/ThumbHash.Tests.csproj
+++ b/test/ThumbHash.Tests/ThumbHash.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net481</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/ThumbHash.Tests/ThumbHash.Tests.csproj
+++ b/test/ThumbHash.Tests/ThumbHash.Tests.csproj
@@ -25,9 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.3" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/ThumbHash.Tests/ThumbHash.Tests.csproj
+++ b/test/ThumbHash.Tests/ThumbHash.Tests.csproj
@@ -26,14 +26,14 @@
 
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -6,7 +6,7 @@ public class ThumbHashTests
 {
     private static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
 
-    private static byte[] FlowerThumbHash => new byte[] { 147, 74, 6, 45, 6, 146, 86, 195, 116, 5, 88, 103, 218, 138, 182, 103, 148, 144, 81, 7, 25 };
+    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
 
     private static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
 
@@ -16,7 +16,7 @@ public class ThumbHashTests
 
     private static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
 
-    private static byte[] TuxThumbHash => Convert.FromHexString("A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06".Replace(" ", ""));
+    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
 
     private static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
 

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -30,10 +30,6 @@ public class ThumbHashTests
             Assert.Equal(rendered.Width, w);
             Assert.Equal(rendered.Height, h);
 
-            var spanBytes = new byte[w * h * 4];
-            _ = th.ToImage(spanBytes);
-            Assert.Equal(thRenderedBytes, spanBytes);
-
             {
                 using var hash_img = SKImage.FromPixelCopy(new(w, h, SKColorType.Rgba8888, SKAlphaType.Unpremul), thRenderedBytes);
                 using var hash_data_png = hash_img.Encode(SKEncodedImageFormat.Png, 100);

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -1,0 +1,56 @@
+﻿using SkiaSharp;
+
+namespace ThumbHashes.Tests;
+using static Resources;
+
+public class ThumbHashTests
+{
+    public static IEnumerable<object[]> TestThumbHashes
+    {
+        get
+        {
+            yield return new object[] { FlowerThumbHash, FlowerThumbHashRendered, FlowerBitmap, FlowerAspectRatio, FlowerThumbHashAverages };
+            yield return new object[] { TuxThumbHash, TuxThumbHashRendered, TuxBitmap, TuxAspectRatio, TuxThumbHashAverages };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TestThumbHashes))]
+    public void ValidateThumbHash(byte[] hash, SKBitmap rendered, SKBitmap original, float aspectRatio, (float r, float g, float b, float a) averages)
+    {
+        using (rendered)
+        using (original)
+        {
+            var th = new ThumbHash(hash);
+            Assert.Equal(hash, th.Hash);
+            Assert.Equal(aspectRatio, th.ApproximateAspectRatio);
+            Assert.Equal(averages, th.AverageColor);
+
+            var (w, h, thRenderedBytes) = th.ToImage();
+            Assert.Equal(rendered.Width, w);
+            Assert.Equal(rendered.Height, h);
+
+            var spanBytes = new byte[w * h * 4];
+            _ = th.ToImage(spanBytes);
+            Assert.Equal(thRenderedBytes, spanBytes);
+
+            {
+                using var hash_img = SKImage.FromPixelCopy(new(w, h, SKColorType.Rgba8888, SKAlphaType.Unpremul), thRenderedBytes);
+                using var hash_data_png = hash_img.Encode(SKEncodedImageFormat.Png, 100);
+                using var hash_bmp = SKBitmap.Decode(hash_data_png);
+
+                Assert.Equal(rendered.Pixels, hash_bmp.Pixels);
+            }
+
+            {
+                var thRecreated = ThumbHash.FromImage(original.Width, original.Height, original.GetPixelSpan());
+                //can't just compare th <-> thRecreated because
+                //ROM/ROS's equality does not check contents
+                // "This tests if two ReadOnlySpan<T> instances point to the same starting memory location,
+                // and have the same Length values. This does not compare the contents of two ReadOnlySpan<T> instances."
+                // https://learn.microsoft.com/en-us/dotnet/api/system.readonlyspan-1.op_equality?view=net-7.0#remarks
+                Assert.True(th.Hash.Span.SequenceEqual(thRecreated.Hash.Span));
+            }
+        }
+    }
+}

--- a/test/ThumbHash.Tests/UtilitiesTests.cs
+++ b/test/ThumbHash.Tests/UtilitiesTests.cs
@@ -1,8 +1,9 @@
 using SkiaSharp;
+using System.Buffers;
 
-namespace ThumbHash.Tests;
+namespace ThumbHashes.Tests;
 
-public class ThumbHashTests
+public class UtilitiesTests
 {
     private static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
 
@@ -74,29 +75,29 @@ public class ThumbHashTests
     public void RgbaToThumbHash(SKBitmap expected_img, byte[] expected_thumbhash)
     {
         using var img = expected_img;
-        var thumbhash = ThumbHash.RgbaToThumbHash(img.Width, img.Height, img.GetPixelSpan());
+        var thumbhash = Utilities.RgbaToThumbHash(img.Width, img.Height, img.GetPixelSpan());
         Assert.Equal(thumbhash, expected_thumbhash);
     }
 
     [Fact]
     public void RgbaToThumbHash_ThrowsOnBadDimensions()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("w", () => ThumbHash.RgbaToThumbHash(101, 1, stackalloc byte[101 * 1 * 4]));
-        Assert.Throws<ArgumentOutOfRangeException>("h", () => ThumbHash.RgbaToThumbHash(1, 101, stackalloc byte[1 * 101 * 4]));
+        Assert.Throws<ArgumentOutOfRangeException>("w", () => Utilities.RgbaToThumbHash(101, 1, stackalloc byte[101 * 1 * 4]));
+        Assert.Throws<ArgumentOutOfRangeException>("h", () => Utilities.RgbaToThumbHash(1, 101, stackalloc byte[1 * 101 * 4]));
     }
 
     [Fact]
     public void RgbaToThumbHash_ThrowsOnBadPixelSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[3]));
-        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => ThumbHash.RgbaToThumbHash(1, 1, stackalloc byte[5]));
+        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => Utilities.RgbaToThumbHash(1, 1, stackalloc byte[3]));
+        Assert.Throws<ArgumentOutOfRangeException>("rgba_bytes.Length", () => Utilities.RgbaToThumbHash(1, 1, stackalloc byte[5]));
     }
 
     [Theory]
     [MemberData(nameof(TestThumbHashes))]
     public void ThumbHashToRgba(byte[] thumbhash, SKBitmap thumbhash_rendered)
     {
-        var (w, h, hash_rgba) = ThumbHash.ThumbHashToRgba(thumbhash);
+        var (w, h, hash_rgba) = Utilities.ThumbHashToRgba(thumbhash);
 
         //some pixels are zeroed out in the png form so we round-trip this to make it match the expected png
         using var hash_img = SKImage.FromPixelCopy(new(w, h, SKColorType.Rgba8888, SKAlphaType.Unpremul), hash_rgba);
@@ -123,13 +124,13 @@ public class ThumbHashTests
     [Fact]
     public void ThumbHashToRgba_ThrowsOnBadHashSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("hash.Length", () => ThumbHash.ThumbHashToRgba(stackalloc byte[4]));
+        Assert.Throws<ArgumentOutOfRangeException>("hash.Length", () => Utilities.ThumbHashToRgba(stackalloc byte[4]));
     }
 
     [Fact]
     public void ThumbHashToRgba_ThrowsOnBadRgbaSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("rgba.Length", () => ThumbHash.ThumbHashToRgba(FlowerThumbHash, stackalloc byte[4]));
+        Assert.Throws<ArgumentOutOfRangeException>("rgba.Length", () => Utilities.ThumbHashToRgba(FlowerThumbHash, stackalloc byte[4]));
     }
 
     [Theory]
@@ -137,7 +138,7 @@ public class ThumbHashTests
     public void ThumbHashToAverageRgba(byte[] thumbhash, (float r, float g, float b, float a) averages)
     {
         var expected = averages;
-        var actual = ThumbHash.ThumbHashToAverageRgba(thumbhash);
+        var actual = Utilities.ThumbHashToAverageRgba(thumbhash);
 
         Assert.Equal(expected, actual);
     }
@@ -145,7 +146,7 @@ public class ThumbHashTests
     [Fact]
     public void ThumbHashToAverageRgba_ThrowsOnBadHashSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ThumbHash.ThumbHashToAverageRgba(stackalloc byte[4]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Utilities.ThumbHashToAverageRgba(stackalloc byte[4]));
     }
 
     [Theory]
@@ -153,7 +154,7 @@ public class ThumbHashTests
     public void ThumbHashToApproximateAspectRatio(byte[] thumbhash, float aspectRatio)
     {
         var expected = aspectRatio;
-        var actual = ThumbHash.ThumbHashToApproximateAspectRatio(thumbhash);
+        var actual = Utilities.ThumbHashToApproximateAspectRatio(thumbhash);
 
         Assert.Equal(expected, actual);
     }
@@ -161,6 +162,6 @@ public class ThumbHashTests
     [Fact]
     public void ThumbHashToApproximateAspectRatio_ThrowsOnBadHashSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ThumbHash.ThumbHashToApproximateAspectRatio(stackalloc byte[4]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Utilities.ThumbHashToApproximateAspectRatio(stackalloc byte[4]));
     }
 }

--- a/test/ThumbHash.Tests/UtilitiesTests.cs
+++ b/test/ThumbHash.Tests/UtilitiesTests.cs
@@ -1,39 +1,10 @@
 using SkiaSharp;
-using System.Buffers;
 
 namespace ThumbHashes.Tests;
+using static Resources;
 
 public class UtilitiesTests
 {
-    private static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
-
-    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
-
-    private static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
-
-    private static SKBitmap FlowerThumbHashRendered => GetBitmap("Resources/flower_thumbhash_rust.png");
-
-    private const float FlowerAspectRatio = 0.714285731f;
-
-    private static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
-
-    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
-
-    private static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
-
-    private static SKBitmap TuxThumbHashRendered => GetBitmap("Resources/tux_thumbhash_rust.png");
-
-    private const float TuxAspectRatio = 0.800000011f;
-
-    private static SKBitmap GetBitmap(string path, bool fixPremul = false)
-    {
-        using var skbmp = fixPremul
-            ? SKBitmap.Decode(path, SKBitmap.DecodeBounds(path).WithAlphaType(SKAlphaType.Unpremul))
-            : SKBitmap.Decode(path);
-        var result = skbmp.Copy(SKColorType.Rgba8888);
-        return result;
-    }
-
     public static IEnumerable<object[]> TestImages
     {
         get


### PR DESCRIPTION
* Change the root namespace to `ThumbHashes` to avoid having to explicitly specify `ThumbHash.ThumbHash` for any operations. Sorry for the breaking change.
* The old `ThumbHash` class is now `Utilities` and contains the same raw manipulation APIs and Span-based implementations for high performance.
* There is a new `ThumbHash` type with easy-to-use APIs for working with ThumbHashes.
* Add `netstandard2.0` support.
* Add usage examples to README.