### PR TITLE
Update docs and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A very compact representation of a placeholder for an image. Store it inline wit
 
 |Image|ThumbHash|ThumbHash Image|
 |-----|---------|---------------|
-|![Flower](assets/flower.jpg)|93 4A 06 2D 06 92 56 C3 74 05 58 67 DA 8A B6 67 94 90 51 07 19|<img alt="Flower ThumbHash" src="/assets/flower_thumbhash_rust.png" width=75 height=100>|
-|![Tux](assets/tux.png)|A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06|<img alt="Tux ThumbHash" src="/assets/tux_thumbhash_rust.png" width=84 height=100>|
+|![Flower](https://github.com/jzebedee/ThumbHash/blob/master/assets/flower.jpg?raw=1)|93 4A 06 2D 06 92 56 C3 74 05 58 67 DA 8A B6 67 94 90 51 07 19|<img alt="Flower ThumbHash" src="https://github.com/jzebedee/ThumbHash/blob/master/assets/flower_thumbhash_rust.png?raw=1" width=75 height=100>|
+|![Tux](https://github.com/jzebedee/ThumbHash/blob/master/assets/tux.png?raw=1)|A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06|<img alt="Tux ThumbHash" src="https://github.com/jzebedee/ThumbHash/blob/master/assets/tux_thumbhash_rust.png?raw=1" width=84 height=100>|
 
 [See a demo of ThumbHash in action _here_](https://evanw.github.io/thumbhash/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ThumbHash
+# [ThumbHash](https://github.com/jzebedee/ThumbHash)
 
 [![ThumbHash nuget package](https://img.shields.io/nuget/v/ThumbHash.svg?style=flat)](https://www.nuget.org/packages/ThumbHash)
 [![CI build-test-pack](https://github.com/jzebedee/ThumbHash/actions/workflows/ci.yml/badge.svg)](https://github.com/jzebedee/ThumbHash/actions/workflows/ci.yml)

--- a/bench/ThumbHash.Benchmarks.csproj
+++ b/bench/ThumbHash.Benchmarks.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.8" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	<LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <IsTrimmable>true</IsTrimmable>
     <RootNamespace>ThumbHashes</RootNamespace>
 
 	<Product>ThumbHash</Product>
@@ -22,6 +21,13 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+	
+  <!-- Trimming support -->
+  <!-- see:  Breaking change: IsTrimmable for netstandard libs #36775 -->
+  <!-- https://github.com/dotnet/docs/pull/36775 -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 	
   <!-- Source Link Support -->

--- a/src/ThumbHash/ThumbHash.csproj
+++ b/src/ThumbHash/ThumbHash.csproj
@@ -9,7 +9,7 @@
 
 	<Product>ThumbHash</Product>
 	<Authors>jzebedee</Authors>
-	<VersionPrefix>2.1</VersionPrefix>
+	<VersionPrefix>2.1.1</VersionPrefix>
 	<Description>A very compact representation of a placeholder for an image. Store it inline with your data and show it while the real image is loading for a smoother loading experience.</Description>
 	<PackageProjectUrl>https://github.com/jzebedee/ThumbHash</PackageProjectUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/ThumbHash.Tests/ThumbHash.Tests.csproj
+++ b/test/ThumbHash.Tests/ThumbHash.Tests.csproj
@@ -25,14 +25,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.3" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.6" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ThumbHash.Tests/ThumbHashTests.cs
+++ b/test/ThumbHash.Tests/ThumbHashTests.cs
@@ -6,7 +6,7 @@ public class ThumbHashTests
 {
     private static SKBitmap FlowerBitmap => GetBitmap("Resources/flower.jpg");
 
-    private static byte[] FlowerThumbHash => new byte[] { 147, 74, 6, 45, 6, 146, 86, 195, 116, 5, 88, 103, 218, 138, 182, 103, 148, 144, 81, 7, 25 };
+    private static byte[] FlowerThumbHash => Convert.FromHexString("934A062D069256C374055867DA8AB6679490510719");
 
     private static (float r, float g, float b, float a) FlowerThumbHashAverages => (r: 0.484127015f, g: 0.341269821f, b: 0.0793650597f, a: 1f);
 
@@ -16,7 +16,7 @@ public class ThumbHashTests
 
     private static SKBitmap TuxBitmap => GetBitmap("Resources/tux.png", fixPremul: true);
 
-    private static byte[] TuxThumbHash => Convert.FromHexString("A1 19 8A 1C 02 38 3A 25 D7 27 F6 8B 97 1F F7 F9 71 7F 80 37 67 58 98 79 06".Replace(" ", ""));
+    private static byte[] TuxThumbHash => Convert.FromHexString("A1198A1C02383A25D727F68B971FF7F9717F80376758987906");
 
     private static (float r, float g, float b, float a) TuxThumbHashAverages => (r: 0.616402208f, g: 0.568783104f, b: 0.386243373f, a: 0.533333361f);
 


### PR DESCRIPTION
* Fix broken links in NuGet (non-GH) readme
* Bump package versions related to SkiaSharp CVE-2023-4863
* Avoid net8 SDK trimming warning